### PR TITLE
Fix Docker Hub push workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,26 @@
+name: Build Docker image
+
+on:
+  schedule:
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: docker.io/${{ secrets.DOCKERHUB_USERNAME }}/h5p-cli:latest
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Node dependencies
+node_modules/
+
+# Docker files
+*.tar
+*.log
+
+# Editor
+*.swp

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:18-slim
+LABEL maintainer="Your Name <you@example.com>"
+
+# Install H5P CLI globally
+RUN npm install -g h5p h5p-cli
+
+# Pre-install common H5P library so users don't need to download it later
+RUN h5p setup h5p-course-presentation
+
+# Set default workdir
+WORKDIR /data
+
+CMD ["bash"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,31 @@
 # h5p_cli_docker
-This aims to be a repo to generate images of h5p monthly in an automatic manner
+
+This project provides a Docker image containing the [H5P CLI](https://github.com/h5p/h5p-cli). The image is built automatically every month using GitHub Actions.
+
+## Usage
+
+Build the image locally:
+
+```bash
+docker build -t h5p-cli .
+```
+
+Alternatively, pull the prebuilt image from Docker Hub:
+
+```bash
+docker pull <your_dockerhub_username>/h5p-cli:latest
+```
+
+Run the container:
+
+```bash
+docker run -it h5p-cli h5p --help
+```
+
+The container includes the `h5p-course-presentation` library downloaded during
+the image build. This allows you to work offline without waiting for the
+dependencies to be fetched.
+
+## Automation
+
+The workflow defined in `.github/workflows/docker-image.yml` builds the image and pushes it to Docker Hub on the first day of every month.


### PR DESCRIPTION
## Summary
- push Docker images to Docker Hub instead of GHCR
- document pulling the image from Docker Hub

## Testing
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878ad8189f48322bde1132de77a2cbd