### PR TITLE
Fix h5p setup command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN mkdir -p /usr/local/lib/h5p \
     && cd /usr/local/lib/h5p \
     && h5p core --yes \
     && h5p list | awk '/^h5p/ {print $1}' | \
-        xargs -I{} sh -c 'h5p setup "$1" --yes || h5p setup "$1" master --yes || h5p setup "$1" main --yes' _ {}
+        xargs -I{} sh -c 'h5p --yes setup "$1" || h5p --yes setup "$1" master || h5p --yes setup "$1" main' _ {}
 
 
 # Set default workdir


### PR DESCRIPTION
## Summary
- fix Dockerfile commands so `--yes` is treated as a global option when setting up libraries

## Testing
- `docker build -t h5p-cli-test .` *(fails: `docker` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878c4ab6c448322bd3343f245f91a4b