### PR TITLE
Fix h5p setup commands

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,9 @@ RUN npm install -g h5p-cli \
 # Pre-install all H5P libraries so users can work offline
 RUN mkdir -p /usr/local/lib/h5p \
     && cd /usr/local/lib/h5p \
-    && h5p core --yes \
+    && h5p core \
     && h5p list | awk '/^h5p/ {print $1}' | \
-        xargs -I{} sh -c 'h5p --yes setup "$1" || h5p --yes setup "$1" master || h5p --yes setup "$1" main' _ {}
+        xargs -I{} sh -c 'h5p setup "$1" || h5p setup "$1" master || h5p setup "$1" main' _ {}
 
 
 # Set default workdir


### PR DESCRIPTION
## Summary
- remove unsupported `--yes` flag from Dockerfile

## Testing
- `npm install -g h5p-cli`
- `h5p core` *(fails: ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6878cc9aa800832288e25b8e3cbd99fd